### PR TITLE
Support RegExp groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 1.0.9 Aug 20, 2025
+### 1.1.0 Sep 3, 2025
  - Allow Regex groups to be used in replacement
 ### 1.0.8 Aug 28, 2024
  - Update README.md with a more verbose example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.0.9 Aug 20, 2025
+ - Allow Regex groups to be used in replacement
 ### 1.0.8 Aug 28, 2024
  - Update README.md with a more verbose example
 ### 1.0.6 July 22, 2024

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To create a rule that automatically converts Jira issue keys into clickable link
 ## Using RegExp groups
 
 RegExp groups are completely supported, by using the group number or name in the replacement link.
-For example, in a string `There is some target-words-123456 in a sentence` the pattern `target-(?<name>[a-zA-Z]+)-(?<number>[0-9]+)` allows the following replacements:
+For example, in a string `This is an example sentence where target-words-123456 will be replaced.` the pattern `target-(?<name>[a-zA-Z]+)-(?<number>[0-9]+)` allows the following replacements:
 
 | replacement | value |
 | ----------- | ----- |
@@ -41,7 +41,7 @@ For example, in a string `There is some target-words-123456 in a sentence` the p
 | `{name}` | "words" |
 | `{number}` | "123456" |
 
-A link `https://example.com/{name}/{number}` would then become `https://example.com/words/123456`
+With the above pattern and a target link `https://example.com/{name}/{number}`, the example string from above would then become `This is an example sentence where [target-words-123456](https://example.com/words/123456) will be replaced.`.
 
 # Support and Feedback
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ To create a rule that automatically converts Jira issue keys into clickable link
 
 ![An image showing the settings page for LinkMagic with an example pattern](example.png)
 
+## Using RegExp groups
+
+RegExp groups are completely supported, by using the group number or name in the replacement link.
+For example, in a string `There is some target-words-123456 in a sentence` the pattern `target-(?<name>[a-zA-Z]+)-(?<number>[0-9]+)` allows the following replacements:
+
+| replacement | value |
+| ----------- | ----- |
+| `{0}` | "target-words-123456" |
+| `{1}` | "words" |
+| `{2}` | "123456" |
+| `{pattern}` | "target-words-123456" |
+| `{name}` | "words" |
+| `{number}` | "123456" |
+
+A link `https://example.com/{name}/{number}` would then become `https://example.com/words/123456`
 
 # Support and Feedback
 

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,5 @@
 import { App, Editor, EditorPosition, Plugin, PluginSettingTab, Setting } from 'obsidian';
+import { replacePattern } from 'replacePattern';
 
 
 type PluginSettings = Record<string, { pattern: string, link: string }>;
@@ -68,7 +69,7 @@ export default class LinkMagicPlugin extends Plugin {
 						const startChar = match[1] || ""
 						const innerWord = match[2]
 						const endChar = match[3] || ""
-						let markdownLink = `${startChar}[${innerWord}](${link.replace("{pattern}", innerWord)})${endChar}`
+						let markdownLink = `${startChar}[${innerWord}](${replacePattern(link, regex, innerWord)})${endChar}`
 						editor.replaceRange(markdownLink, { line: curPos.line, ch: curPos.ch - word.length }, curPos);
 					}
 				}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "link-magic",
 	"name": "LinkMagic",
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"minAppVersion": "0.15.0",
 	"description": "Automatically adds links to defined regex.",
 	"author": "Andrew Reifman",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "link-magic",
 	"name": "LinkMagic",
-	"version": "1.0.9",
+	"version": "1.1.0",
 	"minAppVersion": "0.15.0",
 	"description": "Automatically adds links to defined regex.",
 	"author": "Andrew Reifman",

--- a/replacePattern.ts
+++ b/replacePattern.ts
@@ -1,15 +1,29 @@
-export function replacePattern(link: string, pattern: RegExp, innerWord: string) {
+/**
+ * Finds all RegExp groups in the innerWord and uses them to replace matching group in the target string with their replacement from the inner word.
+ * The group name {pattern} is kept for backwards compatibility. This group gets replaced with the full innerWord.
+ * @param target The target string to do all replacements in
+ * @param pattern
+ * @param innerWord The keyword from the source text that triggered this replacement
+ * @returns a string based on the target string, in which all occurences of group names or numbers are replaced with their matching group in the innerWord
+ */
+export function replacePattern(target: string, pattern: RegExp, innerWord: string) {
   const groups = findGroups(innerWord, pattern);
 
   const replacements = [["pattern", innerWord], ...groups];
 
   return replacements.reduce((acc, [groupName, replacement]) => {
     return replaceGroup(acc, groupName, replacement);
-  }, link);
+  }, target);
 }
 
-function findGroups(innerWord: string, pattern: RegExp): string[][] {
-  const matches = pattern.exec(innerWord);
+/**
+ * Lists matching RegExp groups in the input string. This includes numbered and named groups.
+ * @param input 
+ * @param pattern 
+ * @returns An array of [groupName, replacement] tuples
+ */
+function findGroups(input: string, pattern: RegExp): string[][] {
+  const matches = pattern.exec(input);
   if (!matches) {
     return [];
   }
@@ -22,6 +36,13 @@ function findGroups(innerWord: string, pattern: RegExp): string[][] {
   return [...numberedGroups, ...namedGroups];
 }
 
+/**
+ * Replaces a substring {groupName} in the input string with the replacement
+ * @param input
+ * @param groupName 
+ * @param replacement 
+ * @returns The string with the replaced values
+ */
 function replaceGroup(input: string, groupName: string, replacement: string): string {
   return input.replace(`{${groupName}}`, replacement);
 }

--- a/replacePattern.ts
+++ b/replacePattern.ts
@@ -1,4 +1,4 @@
-export function replacePattern(link: string, pattern: string, innerWord: string) {
+export function replacePattern(link: string, pattern: RegExp, innerWord: string) {
   const groups = findGroups(innerWord, pattern);
 
   const replacements = [["pattern", innerWord], ...groups];
@@ -8,8 +8,8 @@ export function replacePattern(link: string, pattern: string, innerWord: string)
   }, link);
 }
 
-function findGroups(innerWord: string, pattern: string): string[][] {
-  const matches = new RegExp(pattern, "g").exec(innerWord);
+function findGroups(innerWord: string, pattern: RegExp): string[][] {
+  const matches = pattern.exec(innerWord);
   if (!matches) {
     return [];
   }

--- a/replacePattern.ts
+++ b/replacePattern.ts
@@ -1,0 +1,27 @@
+export function replacePattern(link: string, pattern: string, innerWord: string) {
+  const groups = findGroups(innerWord, pattern);
+
+  const replacements = [["pattern", innerWord], ...groups];
+
+  return replacements.reduce((acc, [groupName, replacement]) => {
+    return replaceGroup(acc, groupName, replacement);
+  }, link);
+}
+
+function findGroups(innerWord: string, pattern: string): string[][] {
+  const matches = new RegExp(pattern, "g").exec(innerWord);
+  if (!matches) {
+    return [];
+  }
+  const numberedGroups = Object.entries(matches)
+    .filter(([key]) => !isNaN(Number(key)));
+  
+  const groups = matches.groups || {};
+  const namedGroups = Object.entries(groups);
+
+  return [...numberedGroups, ...namedGroups];
+}
+
+function replaceGroup(input: string, groupName: string, replacement: string): string {
+  return input.replace(`{${groupName}}`, replacement);
+}

--- a/replacePattern.ts
+++ b/replacePattern.ts
@@ -37,12 +37,12 @@ function findGroups(input: string, pattern: RegExp): string[][] {
 }
 
 /**
- * Replaces a substring {groupName} in the input string with the replacement
+ * Replaces all substrings {groupName} in the input string with the replacement
  * @param input
  * @param groupName 
  * @param replacement 
  * @returns The string with the replaced values
  */
 function replaceGroup(input: string, groupName: string, replacement: string): string {
-  return input.replace(`{${groupName}}`, replacement);
+  return input.replace(new RegExp(`\\{${groupName}\\}`, 'g'), replacement);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,12 +10,13 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "isolatedModules": true,
-	"strictNullChecks": true,
+	  "strictNullChecks": true,
     "lib": [
       "DOM",
       "ES5",
       "ES6",
-      "ES7"
+      "ES7",
+      "ES2018"
     ]
   },
   "include": [


### PR DESCRIPTION
This would add support for RegExp groups as suggested in #15 

Examples (also added to README):

In a string `There is some target-words-123456 in a sentence` the pattern `target-(?<name>[a-zA-Z]+)-(?<idnr>[0-9]+)` allows the following replacements:

| replacement | value |
| ----------- | ----- |
| `{0}` | "target-words-123456" |
| `{1}` | "words" |
| `{2}` | "123456" |
| `{pattern}` | "target-words-123456" |
| `{name}` | "words" |
| `{indr}` | "123456" |

A link `https://example.com/{name}/{idnr}` would then become `https://example.com/words/123456`