### PR TITLE
Reset lastIndex on global RegExp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.1.1 Sep 4, 2025
+ - Fixes a bug where RegExp with global modifier doesn't replace groups
 ### 1.1.0 Sep 3, 2025
  - Allow Regex groups to be used in replacement
 ### 1.0.8 Aug 28, 2024

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "link-magic",
 	"name": "LinkMagic",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"minAppVersion": "0.15.0",
 	"description": "Automatically adds links to defined regex.",
 	"author": "Andrew Reifman",

--- a/replacePattern.ts
+++ b/replacePattern.ts
@@ -23,6 +23,8 @@ export function replacePattern(target: string, pattern: RegExp, innerWord: strin
  * @returns An array of [groupName, replacement] tuples
  */
 function findGroups(input: string, pattern: RegExp): string[][] {
+  // Due to the global flag keeping track of the lastIndex, we need to reset the pattern here
+  pattern.lastIndex = 0;
   const matches = pattern.exec(input);
   if (!matches) {
     return [];


### PR DESCRIPTION
Fixes a bug introduced by #18 

Fixes #15 